### PR TITLE
JIRA-22: Use HTTP Basic authentication.

### DIFF
--- a/jira-macro/jira-macro-default/pom.xml
+++ b/jira-macro/jira-macro-default/pom.xml
@@ -54,6 +54,10 @@
       <groupId>org.jdom</groupId>
       <artifactId>jdom2</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.xwiki.rendering</groupId>

--- a/jira-macro/jira-macro-default/src/test/java/org/xwiki/contrib/jira/macro/internal/source/AbstractJIRADataSourceTest.java
+++ b/jira-macro/jira-macro-default/src/test/java/org/xwiki/contrib/jira/macro/internal/source/AbstractJIRADataSourceTest.java
@@ -19,16 +19,28 @@
  */
 package org.xwiki.contrib.jira.macro.internal.source;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
 import java.util.Collection;
 
+import org.apache.commons.codec.binary.Base64;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.MatcherAssert;
+import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.input.SAXBuilder;
 import org.junit.Test;
 import org.xwiki.contrib.jira.config.JIRAServer;
 import org.xwiki.contrib.jira.macro.JIRAMacroParameters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import com.sun.jdi.connect.spi.Connection;
+
+import ch.qos.logback.core.boolex.Matcher;
 
 /**
  * Unit tests for {@link AbstractJIRADataSource}.
@@ -71,4 +83,54 @@ public class AbstractJIRADataSourceTest
                 + "searchrequest-xml/temp/SearchRequest.xml?jqlQuery=xxx]", expected.getMessage());
         }
     }
+
+    @Test
+    public void testGetXMLDocumentUsesHttpBasicAuthWithCredentials() throws Exception
+    {
+        String urlString = "http://localhost/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?"
+                + "jqlQuery=query";
+        String base64Creds = Base64.encodeBase64String("username:password".getBytes());
+        JIRAServer jiraServer = new JIRAServer("http://localhost/jira", "username", "password");
+
+        AbstractJIRADataSource jiraDataSource = new TestableAbstractJIRADataSource();
+        AbstractJIRADataSource spyDataSource = spy(jiraDataSource);
+        InputStream is = mock(InputStream.class);
+        Document doc = mock(Document.class);
+        URLConnection connection = mock(URLConnection.class);
+        SAXBuilder saxBuilder = mock(SAXBuilder.class);
+
+        doReturn(saxBuilder).when(spyDataSource).createSAXBuilder();
+        doReturn(doc).when(saxBuilder).build(is);
+        doReturn(connection).when(spyDataSource).newConnectionFromUrl( eq( new URL(urlString) ) ) ;
+        doReturn(is).when(connection).getInputStream();
+
+        Document actualDoc = spyDataSource.getXMLDocument(jiraServer, "query", -1);
+        assertSame(doc, actualDoc);
+        verify(connection).setRequestProperty("Authorization", "Basic " + base64Creds);
+    }
+
+    @Test
+    public void testGetXMLDocumentDoesNotHttpBasicAuthWithNoPassword() throws Exception
+    {
+        String urlString = "http://localhost/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?"
+                + "jqlQuery=query";
+        JIRAServer jiraServer = new JIRAServer("http://localhost/jira", "username", null);
+
+        AbstractJIRADataSource jiraDataSource = new TestableAbstractJIRADataSource();
+        AbstractJIRADataSource spyDataSource = spy(jiraDataSource);
+        InputStream is = mock(InputStream.class);
+        Document doc = mock(Document.class);
+        URLConnection connection = mock(URLConnection.class);
+        SAXBuilder saxBuilder = mock(SAXBuilder.class);
+
+        doReturn(saxBuilder).when(spyDataSource).createSAXBuilder();
+        doReturn(doc).when(saxBuilder).build(is);
+        doReturn(connection).when(spyDataSource).newConnectionFromUrl( eq( new URL(urlString) ) ) ;
+        doReturn(is).when(connection).getInputStream();
+
+        Document actualDoc = spyDataSource.getXMLDocument(jiraServer, "query", -1);
+        assertSame(doc, actualDoc);
+        verify(connection, never()).setRequestProperty(eq("Authorization"), any(String.class));
+    }
+
 }

--- a/jira-macro/jira-macro-default/src/test/java/org/xwiki/contrib/jira/macro/internal/source/ListJIRADataSourceTest.java
+++ b/jira-macro/jira-macro-default/src/test/java/org/xwiki/contrib/jira/macro/internal/source/ListJIRADataSourceTest.java
@@ -173,22 +173,11 @@ public class ListJIRADataSourceTest
         assertEquals("http://localhost/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=query",
             this.mocker.getComponentUnderTest().computeFullURL(jiraServer, "query", -1));
 
-        // With credentials
-        jiraServer = new JIRAServer("http://localhost/jira", "username", "password");
-        assertEquals("http://localhost/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?"
-            + "jqlQuery=query&os_username=username&os_password=password&os_authType=basic",
-            this.mocker.getComponentUnderTest().computeFullURL(jiraServer, "query", -1));
-
-        // With Max Count + credentials
-        jiraServer = new JIRAServer("http://localhost/jira", "username", "password");
-        assertEquals("http://localhost/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?"
-                + "jqlQuery=query&os_username=username&os_password=password&os_authType=basic&tempMax=5",
-            this.mocker.getComponentUnderTest().computeFullURL(jiraServer, "query", 5));
-
         // With Max Count and no credentials
         jiraServer = new JIRAServer("http://localhost/jira");
         assertEquals("http://localhost/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?"
                 + "jqlQuery=query&tempMax=5",
             this.mocker.getComponentUnderTest().computeFullURL(jiraServer, "query", 5));
     }
+
 }


### PR DESCRIPTION
I verified the code works against a live hosted Jira instance, and mocked out the connection-specific code in the unit test. However, some of the macro tests are failing, possibly due to the mocking in RenderingTest not playing nicely. If its something relatively straightforward and someone points me in the right direction, I'll see if I can update this PR. 

Thanks. 