### PR TITLE
JIRA-70: The Jira macro inserts a paragraph when used in inline mode

### DIFF
--- a/jira-macro/jira-macro-platform/src/main/java/org/xwiki/contrib/jira/config/internal/JIRABlockAsyncRenderer.java
+++ b/jira-macro/jira-macro-platform/src/main/java/org/xwiki/contrib/jira/config/internal/JIRABlockAsyncRenderer.java
@@ -113,6 +113,7 @@ public class JIRABlockAsyncRenderer extends AbstractBlockAsyncRenderer
             this.asyncContext.useEntity(this.sourceReference);
         }
         try {
+            this.context.setInline(this.inline);
             resultBlocks = this.macro.executeCodeMacro(this.parameters, this.content, this.context);
         } catch (MacroExecutionException e) {
             // Display the error in the result


### PR DESCRIPTION
https://jira.xwiki.org/browse/JIRA-70

This issue reproduces when executed inside macros such as `version` and `putfootnote`.

In these cases, the MacroTransformationContext stored in the async renderer macro is updated before the asynchronous call of the jira macro. The inline property is updated to `true`.
