### PR TITLE
JIRA-87  Save Authenticator configuration in Administration don't work with Tomcat

### DIFF
--- a/jira-config/jira-config-ui/src/main/resources/JIRA/JIRAConfigSheet.xml
+++ b/jira-config/jira-config-ui/src/main/resources/JIRA/JIRAConfigSheet.xml
@@ -232,14 +232,17 @@
         // We need to ensure that all fetch request are done before running "form.submit()"
         // overise the reload of the page (triggered by form.submit()) will cancel the fetch requests.
         const form = $('#jiraConfig')[0]
-        const formData = new FormData(form);
+        const urlEncodedData = new URLSearchParams(new FormData(form).entries());
 
         await Promise.all(Object.values(urlMapping).map(async url =&gt; {
             const fetchUrl = `${url}?save=true`
             try {
                 const response = await fetch(fetchUrl, {
                     method: "POST",
-                    body: formData,
+                    headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded'
+                        },
+                    body: urlEncodedData,
                 });
                 if (!response.ok) {
                     console.error("Can't update JIRA authenticator configuration")


### PR DESCRIPTION
Fix: https://jira.xwiki.org/browse/JIRA-87

I used the `application/x-www-form-urlencoded` which is what we user at the other place and from what I tested it seem working.