### PR TITLE
JIRA-106: Empty JIRA.JIRAConfig page created on subwikis creation

### DIFF
--- a/jira-config/jira-config-platform/src/main/java/org/xwiki/contrib/jira/config/internal/JIRAConfigurationMigrator.java
+++ b/jira-config/jira-config-platform/src/main/java/org/xwiki/contrib/jira/config/internal/JIRAConfigurationMigrator.java
@@ -183,8 +183,12 @@ public class JIRAConfigurationMigrator extends AbstractEventListener
         DocumentReference basicAuthConfigRef =
             new DocumentReference(BasicAuthJIRAAuthenticatorFactory.BASIC_AUTH_CONFIG_REFERENCE, wikiReference);
         XWikiDocument basicAuthDoc = xwiki.getDocument(basicAuthConfigRef, context).clone();
-        XWikiDocument jiraServerDoc =
-            xwiki.getDocument(new DocumentReference(wikiId, JIRA, "JIRAConfig"), context).clone();
+        DocumentReference jiraConfigReference = new DocumentReference(wikiId, JIRA, "JIRAConfig");
+        if (!xwiki.exists(jiraConfigReference, context)) {
+            // Avoid to create a new config if any config exit
+            return;
+        }
+        XWikiDocument jiraServerDoc = xwiki.getDocument(jiraConfigReference, context).clone();
         List<BaseObject> jiraServerObjs =
             jiraServerDoc.getXObjects(new DocumentReference(wikiId, JIRA, "JIRAConfigClass"));
 


### PR DESCRIPTION
Fix https://jira.xwiki.org/browse/JIRA-106 by just avoiding to create a configuration if it don't already exist. The migrator is intended to migrate the old configuration. We should ne create a new configuration.